### PR TITLE
Player name

### DIFF
--- a/Assets/Scenes/PlayerName.unity
+++ b/Assets/Scenes/PlayerName.unity
@@ -410,6 +410,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 580430511}
+  - {fileID: 1493163299}
   m_Father: {fileID: 141404252}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -460,7 +461,7 @@ MonoBehaviour:
   m_Interactable: 1
   m_TargetGraphic: {fileID: 276277626}
   m_TextComponent: {fileID: 580430512}
-  m_Placeholder: {fileID: 0}
+  m_Placeholder: {fileID: 1493163300}
   m_ContentType: 0
   m_InputType: 0
   m_AsteriskChar: 42
@@ -478,7 +479,7 @@ MonoBehaviour:
   m_CaretColor: {r: 1, g: 1, b: 1, a: 1}
   m_CustomCaretColor: 0
   m_SelectionColor: {r: 1, g: 1, b: 1, a: 0.7529412}
-  m_Text: Enter Name...
+  m_Text: 
   m_CaretBlinkRate: 1.06
   m_CaretWidth: 1
   m_ReadOnly: 0
@@ -922,7 +923,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Enter Name
+  m_Text: 
 --- !u!222 &580430513
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1306,9 +1307,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1068352021}
-        m_TargetAssemblyTypeName: LevelSelection, Assembly-CSharp
-        m_MethodName: StartScreenDeletePlayerPrefs
+      - m_Target: {fileID: 2047691079}
+        m_TargetAssemblyTypeName: PlayerName, Assembly-CSharp
+        m_MethodName: ConfirmName
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1434,6 +1435,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1412963949}
+  m_CullTransparentMesh: 1
+--- !u!1 &1493163298
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1493163299}
+  - component: {fileID: 1493163301}
+  - component: {fileID: 1493163300}
+  m_Layer: 5
+  m_Name: Placeholder Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1493163299
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493163298}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 276277624}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000011921, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1493163300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493163298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.5254902}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enter Name
+--- !u!222 &1493163301
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493163298}
   m_CullTransparentMesh: 1
 --- !u!1 &1574490065
 GameObject:
@@ -1561,6 +1641,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a4a7e81cd03bf894f8c2f49b5d8ee99b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  saveName: 
   inputText: {fileID: 580430512}
   loadedName: {fileID: 138704323}

--- a/Assets/Scenes/SettingsMenu.unity
+++ b/Assets/Scenes/SettingsMenu.unity
@@ -322,24 +322,14 @@ RectTransform:
   - {fileID: 684149246}
   - {fileID: 522757980}
   m_Father: {fileID: 885096097}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0.5, y: -1}
   m_SizeDelta: {x: 261, y: 178}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &191208094 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8860200733992533180, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
-  m_PrefabInstance: {fileID: 1670955917}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &198846685 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8860200733992533180, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
-  m_PrefabInstance: {fileID: 1592532928}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &201379003
+--- !u!1 &187896825
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -347,40 +337,47 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 201379006}
-  - component: {fileID: 201379005}
-  - component: {fileID: 201379004}
+  - component: {fileID: 187896826}
+  - component: {fileID: 187896830}
+  - component: {fileID: 187896829}
+  - component: {fileID: 187896828}
   m_Layer: 0
-  m_Name: Music Volume Slider
+  m_Name: Change Name Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &201379004
+--- !u!224 &187896826
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187896825}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1952389492}
+  m_Father: {fileID: 885096097}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -130.91, y: -176}
+  m_SizeDelta: {x: 238.36, y: 81.7452}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &187896828
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 201379003}
+  m_GameObject: {fileID: 187896825}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59cf0ed4ea2af1f49996eb595a61c9a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  volumeName: Music
-  volumeLabel: {fileID: 0}
---- !u!114 &201379005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 201379003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -392,7 +389,7 @@ MonoBehaviour:
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_NormalColor: {r: 0.9433962, g: 0.9433962, b: 0.9433962, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -411,40 +408,70 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 651999698}
-  m_FillRect: {fileID: 926277452}
-  m_HandleRect: {fileID: 651999696}
-  m_Direction: 0
-  m_MinValue: 0.0001
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
-  m_OnValueChanged:
+  m_TargetGraphic: {fileID: 187896829}
+  m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
---- !u!224 &201379006
-RectTransform:
+      m_Calls:
+      - m_Target: {fileID: 245167589}
+        m_TargetAssemblyTypeName: LevelSelection, Assembly-CSharp
+        m_MethodName: NameScreen
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+--- !u!114 &187896829
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 201379003}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1157487928}
-  - {fileID: 1235766620}
-  - {fileID: 1175075604}
-  - {fileID: 662281396}
-  m_Father: {fileID: 2014951002}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -121}
-  m_SizeDelta: {x: 160, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_GameObject: {fileID: 187896825}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9725491, g: 0.94117653, b: 0.87843144, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3c4f79aa3cb358e44bd82c3fb6c56210, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.6
+--- !u!222 &187896830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187896825}
+  m_CullTransparentMesh: 1
+--- !u!224 &191208094 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8860200733992533180, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
+  m_PrefabInstance: {fileID: 1670955917}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &198846685 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8860200733992533180, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
+  m_PrefabInstance: {fileID: 1592532928}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &245167588
 GameObject:
   m_ObjectHideFlags: 0
@@ -488,42 +515,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &279052232
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 279052233}
-  m_Layer: 0
-  m_Name: Handle Slide Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &279052233
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 279052232}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2068030063}
-  m_Father: {fileID: 1061367005}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -10, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &288674426
 GameObject:
   m_ObjectHideFlags: 0
@@ -590,85 +581,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &294523215
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 294523216}
-  - component: {fileID: 294523218}
-  - component: {fileID: 294523217}
-  m_Layer: 0
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &294523216
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 294523215}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 973201098}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &294523217
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 294523215}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
-    m_FontSize: 20
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Clear
---- !u!222 &294523218
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 294523215}
-  m_CullTransparentMesh: 1
 --- !u!1 &384213115
 GameObject:
   m_ObjectHideFlags: 0
@@ -985,7 +897,7 @@ GameObject:
   - component: {fileID: 528402037}
   - component: {fileID: 528402038}
   m_Layer: 0
-  m_Name: Master Volume Slider
+  m_Name: Volume Slider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1009,9 +921,9 @@ RectTransform:
   m_Father: {fileID: 2014951002}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -65}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 36}
   m_SizeDelta: {x: 160, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &528402037
@@ -1269,8 +1181,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: -7.5, y: 0}
+  m_SizeDelta: {x: -15, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &617871416
 GameObject:
@@ -1350,192 +1262,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 617871416}
-  m_CullTransparentMesh: 1
---- !u!1 &651999695
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 651999696}
-  - component: {fileID: 651999697}
-  - component: {fileID: 651999698}
-  m_Layer: 0
-  m_Name: Handle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &651999696
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 651999695}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 662281396}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.7999878, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &651999697
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 651999695}
-  m_CullTransparentMesh: 1
---- !u!114 &651999698
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 651999695}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!1 &662281395
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 662281396}
-  m_Layer: 0
-  m_Name: Handle Slide Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &662281396
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 662281395}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 651999696}
-  m_Father: {fileID: 201379006}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -10, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &670186093
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 670186094}
-  - component: {fileID: 670186096}
-  - component: {fileID: 670186095}
-  m_Layer: 0
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &670186094
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 670186093}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1061367005}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &670186095
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 670186093}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &670186096
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 670186093}
   m_CullTransparentMesh: 1
 --- !u!1 &683204578
 GameObject:
@@ -1938,139 +1664,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 732535295}
   m_CullTransparentMesh: 1
---- !u!1 &755892036
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 755892037}
-  - component: {fileID: 755892040}
-  - component: {fileID: 755892039}
-  - component: {fileID: 755892038}
-  m_Layer: 0
-  m_Name: Save Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &755892037
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755892036}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1618838800}
-  m_Father: {fileID: 2014951002}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 69, y: 44.4482}
-  m_SizeDelta: {x: 95, y: 38.8963}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &755892038
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755892036}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 755892039}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 810567439}
-        m_TargetAssemblyTypeName: AudioController, Assembly-CSharp
-        m_MethodName: ApplyChanges
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &755892039
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755892036}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.9946809, b: 0.9946809, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 79dfa496d810aa04f873798f4c6c444c, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.6
---- !u!222 &755892040
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755892036}
-  m_CullTransparentMesh: 1
 --- !u!1 &783358298
 GameObject:
   m_ObjectHideFlags: 0
@@ -2216,8 +1809,8 @@ MonoBehaviour:
   m_profiles: {fileID: 11400000, guid: d4520428afb26f64d8befb34f0940304, type: 2}
   m_VolumeSliders:
   - {fileID: 528402038}
-  - {fileID: 1061367007}
-  - {fileID: 201379004}
+  - {fileID: 0}
+  - {fileID: 0}
 --- !u!82 &810567440
 AudioSource:
   m_ObjectHideFlags: 0
@@ -2667,6 +2260,7 @@ RectTransform:
   - {fileID: 1274862167}
   - {fileID: 683204579}
   - {fileID: 2014951002}
+  - {fileID: 187896826}
   - {fileID: 1342443977}
   - {fileID: 183883682}
   m_Father: {fileID: 0}
@@ -2738,178 +2332,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!1 &926277451
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 926277452}
-  - component: {fileID: 926277455}
-  - component: {fileID: 926277454}
-  - component: {fileID: 926277453}
-  m_Layer: 0
-  m_Name: Fill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &926277452
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926277451}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1175075604}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.800003, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!82 &926277453
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926277451}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &926277454
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926277451}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &926277455
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926277451}
-  m_CullTransparentMesh: 1
 --- !u!1 &959502326
 GameObject:
   m_ObjectHideFlags: 0
@@ -2989,245 +2411,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 959502326}
   m_CullTransparentMesh: 1
---- !u!1 &973201097
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 973201098}
-  - component: {fileID: 973201101}
-  - component: {fileID: 973201100}
-  - component: {fileID: 973201099}
-  m_Layer: 0
-  m_Name: Clear Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &973201098
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 973201097}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 294523216}
-  m_Father: {fileID: 2014951002}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -69, y: 44.448}
-  m_SizeDelta: {x: 95, y: 38.896}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &973201099
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 973201097}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 973201100}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 810567439}
-        m_TargetAssemblyTypeName: AudioController, Assembly-CSharp
-        m_MethodName: CancelChanges
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &973201100
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 973201097}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 79dfa496d810aa04f873798f4c6c444c, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 0.6
---- !u!222 &973201101
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 973201097}
-  m_CullTransparentMesh: 1
---- !u!1 &1061367004
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1061367005}
-  - component: {fileID: 1061367006}
-  - component: {fileID: 1061367007}
-  m_Layer: 0
-  m_Name: Effects Volume Slider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1061367005
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1061367004}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1625088585}
-  - {fileID: 670186094}
-  - {fileID: 1975452920}
-  - {fileID: 279052233}
-  m_Father: {fileID: 2014951002}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -186}
-  m_SizeDelta: {x: 160, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1061367006
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1061367004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 2068030064}
-  m_FillRect: {fileID: 1526567642}
-  m_HandleRect: {fileID: 2068030063}
-  m_Direction: 0
-  m_MinValue: 0.0001
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 1
-  m_OnValueChanged:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!114 &1061367007
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1061367004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59cf0ed4ea2af1f49996eb595a61c9a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  volumeName: Effects
-  volumeLabel: {fileID: 0}
 --- !u!1 &1112877727
 GameObject:
   m_ObjectHideFlags: 0
@@ -3475,121 +2658,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1117958648}
   m_CullTransparentMesh: 1
---- !u!1 &1157487927
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1157487928}
-  - component: {fileID: 1157487930}
-  - component: {fileID: 1157487929}
-  m_Layer: 0
-  m_Name: Music Volume Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1157487928
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1157487927}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 201379006}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 24.999996}
-  m_SizeDelta: {x: 60, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1157487929
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1157487927}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
-    m_FontSize: 18
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Music
---- !u!222 &1157487930
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1157487927}
-  m_CullTransparentMesh: 1
---- !u!1 &1175075603
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1175075604}
-  m_Layer: 0
-  m_Name: Fill Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1175075604
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1175075603}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 926277452}
-  m_Father: {fileID: 201379006}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1222492816
 GameObject:
   m_ObjectHideFlags: 0
@@ -3679,81 +2747,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1222492816}
-  m_CullTransparentMesh: 1
---- !u!1 &1235766619
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1235766620}
-  - component: {fileID: 1235766622}
-  - component: {fileID: 1235766621}
-  m_Layer: 0
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1235766620
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1235766619}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 201379006}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1235766621
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1235766619}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1235766622
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1235766619}
   m_CullTransparentMesh: 1
 --- !u!1 &1274862166
 GameObject:
@@ -3867,11 +2860,11 @@ RectTransform:
   m_Children:
   - {fileID: 617871417}
   m_Father: {fileID: 885096097}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -130.91, y: -398.7}
+  m_AnchoredPosition: {x: -130.91, y: -282}
   m_SizeDelta: {x: 238.36, y: 76.1583}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1342443978
@@ -3967,7 +2960,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.6981132, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.9725491, g: 0.94117653, b: 0.87843144, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -4146,178 +3139,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1489386701}
-  m_CullTransparentMesh: 1
---- !u!1 &1526567641
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1526567642}
-  - component: {fileID: 1526567645}
-  - component: {fileID: 1526567644}
-  - component: {fileID: 1526567643}
-  m_Layer: 0
-  m_Name: Fill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1526567642
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1526567641}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1975452920}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.800003, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!82 &1526567643
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1526567641}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
---- !u!114 &1526567644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1526567641}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1526567645
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1526567641}
   m_CullTransparentMesh: 1
 --- !u!1 &1565639091
 GameObject:
@@ -4524,7 +3345,7 @@ GameObject:
   - component: {fileID: 1579734088}
   - component: {fileID: 1579734087}
   m_Layer: 0
-  m_Name: Master Volume Text
+  m_Name: Volume Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4546,8 +3367,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 60, y: 30}
+  m_AnchoredPosition: {x: -0.5587, y: 28.2066}
+  m_SizeDelta: {x: 211.1766, y: 36.4131}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1579734087
 MonoBehaviour:
@@ -4571,9 +3392,9 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
-    m_FontSize: 18
+    m_FontSize: 32
     m_FontStyle: 0
-    m_BestFit: 0
+    m_BestFit: 1
     m_MinSize: 1
     m_MaxSize: 40
     m_Alignment: 4
@@ -4582,7 +3403,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Master
+  m_Text: Volume
 --- !u!222 &1579734088
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -4612,11 +3433,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 269.4045
+      value: 273.3333
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 43.53183
+      value: 44.583332
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -4664,11 +3485,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 61.601643
+      value: 62.499996
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 49.281315
+      value: 50.416664
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -4716,11 +3537,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 85.420944
+      value: 86.666664
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 33.675564
+      value: 33.333332
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -4911,164 +3732,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1603281499}
   m_CullTransparentMesh: 1
---- !u!1 &1618838799
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1618838800}
-  - component: {fileID: 1618838802}
-  - component: {fileID: 1618838801}
-  m_Layer: 0
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1618838800
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1618838799}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 755892037}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1618838801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1618838799}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
-    m_FontSize: 20
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 20
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Save
---- !u!222 &1618838802
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1618838799}
-  m_CullTransparentMesh: 1
---- !u!1 &1625088584
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1625088585}
-  - component: {fileID: 1625088587}
-  - component: {fileID: 1625088586}
-  m_Layer: 0
-  m_Name: Effects Volume Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1625088585
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625088584}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1061367005}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 60, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1625088586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625088584}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
-    m_FontSize: 18
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Effects
---- !u!222 &1625088587
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1625088584}
-  m_CullTransparentMesh: 1
 --- !u!1001 &1670955917
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5090,11 +3753,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 269.4045
+      value: 273.3333
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 43.53183
+      value: 44.583332
       objectReference: {fileID: 0}
     - target: {fileID: 2885012758652923230, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -5142,11 +3805,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 61.601643
+      value: 62.499996
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 49.281315
+      value: 50.416664
       objectReference: {fileID: 0}
     - target: {fileID: 4739493457776494248, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -5194,11 +3857,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 85.420944
+      value: 86.666664
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 33.675564
+      value: 33.333332
       objectReference: {fileID: 0}
     - target: {fileID: 8495913106789896033, guid: 85588260b7bfe2a44bea5bf4d79cb298, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -6283,7 +4946,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1910336446}
   m_CullTransparentMesh: 1
---- !u!1 &1975452919
+--- !u!1 &1952389491
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6291,34 +4954,77 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1975452920}
+  - component: {fileID: 1952389492}
+  - component: {fileID: 1952389494}
+  - component: {fileID: 1952389493}
   m_Layer: 0
-  m_Name: Fill Area
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1975452920
+--- !u!224 &1952389492
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1975452919}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 1952389491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1526567642}
-  m_Father: {fileID: 1061367005}
-  m_RootOrder: 2
+  m_Children: []
+  m_Father: {fileID: 187896826}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.0958, y: -0.0441}
+  m_SizeDelta: {x: 204.8482, y: 48.8312}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1952389493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952389491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6a0057c47accaec44b795a9e264f05a2, type: 3}
+    m_FontSize: 0
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 1
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Change Name
+--- !u!222 &1952389494
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952389491}
+  m_CullTransparentMesh: 1
 --- !u!1 &1977907368
 GameObject:
   m_ObjectHideFlags: 0
@@ -6427,17 +5133,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 528402035}
-  - {fileID: 201379006}
-  - {fileID: 1061367005}
-  - {fileID: 755892037}
-  - {fileID: 973201098}
   m_Father: {fileID: 885096097}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -130.91, y: -151.3151}
-  m_SizeDelta: {x: 238.36, y: 282.6401}
+  m_AnchoredPosition: {x: -130.91, y: -62.483612}
+  m_SizeDelta: {x: 238.36, y: 104.9772}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2014951003
 MonoBehaviour:
@@ -6452,7 +5154,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.9725491, g: 0.94117653, b: 0.87843144, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -6476,81 +5178,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2014951001}
-  m_CullTransparentMesh: 1
---- !u!1 &2068030062
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2068030063}
-  - component: {fileID: 2068030065}
-  - component: {fileID: 2068030064}
-  m_Layer: 0
-  m_Name: Handle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2068030063
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2068030062}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 279052233}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.7999878, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2068030064
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2068030062}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &2068030065
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2068030062}
   m_CullTransparentMesh: 1
 --- !u!1 &2143079610
 GameObject:

--- a/Assets/Scripts/Achievements/AchievementManager.cs
+++ b/Assets/Scripts/Achievements/AchievementManager.cs
@@ -146,12 +146,12 @@ public class AchievementManager : MonoBehaviour
 
     public int GetAchievementPref(string type, AchievementType achID)
     {
-        return PlayerPrefs.GetInt(achID + "_" + type.ToUpper());
+        return PersistentData.GetInt(achID + "_" + type.ToUpper());
     }
 
     public void SetAchievementPref(string type, AchievementType achID, int value)
     {
-        PlayerPrefs.SetInt(achID + "_" + type.ToUpper(), value);
+        PersistentData.SetInt(achID + "_" + type.ToUpper(), value);
     }
 
     public void ResetAchievements()

--- a/Assets/Scripts/GetPlayerName.cs
+++ b/Assets/Scripts/GetPlayerName.cs
@@ -4,7 +4,26 @@ using UnityEngine;
 
 public class GetPlayerName : MonoBehaviour
 {
-
+    /// <summary>
+    /// !!!DO NOT USE!!! - Access player name with PersistentData class instead
+    /// </summary>
+    /// <remarks>
+    /// Player Name should be accessed by using PersistentData.SetPlayerName(string newName) and PersistentData.GetPlayerName()
+    ///
+    /// Examples:
+    /// Replace:
+    /// string x = GetPlayerName.playerName;
+    /// With:
+    /// string x = PersistentData.GetPlayerName();
+    ///
+    /// Replace:
+    /// GetPlayerName.playerName = "New Player Name";
+    /// With:
+    /// PersistentData.SetPlayerName("New Player Name");
+    ///
+    /// If you have any questions reach out to Marcus
+    /// </remarks>
     public static string playerName;
+    
 
 }

--- a/Assets/Scripts/LevelCompletion.cs
+++ b/Assets/Scripts/LevelCompletion.cs
@@ -8,20 +8,20 @@ public class LevelCompletion
     //Marks the level as completed on Normal difficulty
     public static void NormalLevelCompleted(string SceneName)
     {
-        PlayerPrefs.SetInt(SceneName + " Normal Level Completion Tracker", 1);
+        PersistentData.SetInt(SceneName + " Normal Level Completion Tracker", 1);
     }
 
     //Marks the level as not completed on Normal difficulty
     //Not likely to be needed in final release of the game but could be useful in development.
     public static void NormalLevelResetCompletion(string SceneName)
     {
-        PlayerPrefs.SetInt(SceneName + " Normal Level Completion Tracker", 0);
+        PersistentData.SetInt(SceneName + " Normal Level Completion Tracker", 0);
     }
 
     //Returns true if the level has been completed on Normal difficulty
     public static bool getNormalLevelCompletionStatus(string SceneName)
     {
-        return PlayerPrefs.GetInt(SceneName + " Normal Level Completion Tracker", 0) == 1;
+        return PersistentData.GetInt(SceneName + " Normal Level Completion Tracker", 0) == 1;
     }
 
 
@@ -29,19 +29,19 @@ public class LevelCompletion
     //Marks the level as completed on Hard difficulty
     public static void HardLevelCompleted(string SceneName)
     {
-        PlayerPrefs.SetInt(SceneName + " Hard Level Completion Tracker", 1);
+        PersistentData.SetInt(SceneName + " Hard Level Completion Tracker", 1);
     }
 
     //Marks the level as not completed on Hard difficulty
     //Not likely to be needed in final release of the game but could be useful in development.
     public static void HardLevelResetCompletion(string SceneName)
     {
-        PlayerPrefs.SetInt(SceneName + " Hard Level Completion Tracker", 0);
+        PersistentData.SetInt(SceneName + " Hard Level Completion Tracker", 0);
     }
 
     //Returns true if the level has been completed on Hard difficulty
     public static bool getHardLevelCompletionStatus(string SceneName)
     {
-        return PlayerPrefs.GetInt(SceneName + " Hard Level Completion Tracker", 0) == 1;
+        return PersistentData.GetInt(SceneName + " Hard Level Completion Tracker", 0) == 1;
     }
 }

--- a/Assets/Scripts/LevelSelection.cs
+++ b/Assets/Scripts/LevelSelection.cs
@@ -75,13 +75,17 @@ public class LevelSelection : MonoBehaviour
         SceneManager.LoadScene("StartScreen");
     }
 
+    public void NameScreen()
+    {
+        SceneManager.LoadScene("PlayerName");
+    }
+
 
     public void StartScreenDeletePlayerPrefs()
     {
         
         SceneManager.LoadScene("StartScreen");
     }
-    
 
     public void AchievementSelect()
     {

--- a/Assets/Scripts/PersistentData.cs
+++ b/Assets/Scripts/PersistentData.cs
@@ -9,8 +9,8 @@ public class PersistentData : PlayerPrefs
 {
 
     #region name
-    private static string name = PlayerPrefs.GetString("name", "none");
-    private static string storedKeys = PersistentData.GetString("All_Stored_Keys_For_This_Name");
+    private static string name = PlayerPrefs.GetString("name", "");
+    private static string storedKeys = PersistentData.GetString(name + "_All_Stored_Keys_For_This_Name");
 
     /// <summary>
     ///   <para>Sets the name of the Player name to uniquely generate and retrive keys for each player name.</para>

--- a/Assets/Scripts/PersistentData.cs
+++ b/Assets/Scripts/PersistentData.cs
@@ -10,7 +10,7 @@ public class PersistentData : PlayerPrefs
 
     #region name
     private static string name = PlayerPrefs.GetString("name", "");
-    private static string storedKeys = PersistentData.GetString(name + "_All_Stored_Keys_For_This_Name");
+    private static string storedKeys = PlayerPrefs.GetString(name + "_All_Stored_Keys_For_This_Name","");
 
     /// <summary>
     ///   <para>Sets the name of the Player name to uniquely generate and retrive keys for each player name.</para>
@@ -20,7 +20,7 @@ public class PersistentData : PlayerPrefs
     {
         PlayerPrefs.SetString("name", newName);
         name = newName;
-        storedKeys = PlayerPrefs.GetString(name + "_All_Stored_Preferences_For_This_Name");
+        storedKeys = PlayerPrefs.GetString(name + "_All_Stored_Keys_For_This_Name", "");
     }
 
 
@@ -40,25 +40,40 @@ public class PersistentData : PlayerPrefs
     {
         if (!HasKey(key))
         {
-            storedKeys += ";" + key;
-            SetString("All_Stored_Keys_For_This_Name", storedKeys);
+            if (storedKeys.Length == 0)
+                storedKeys += key;
+            else
+                storedKeys += ";" + key;
+            PlayerPrefs.SetString(name + "_All_Stored_Keys_For_This_Name", storedKeys);
         }
     }
 
-    public static string[] getKeys()
+    /// <summary>
+    /// Returns all of the keys accociated with the current player name
+    /// </summary>
+    /// <returns></returns>
+    public static string[] GetKeys()
     {
-        return storedKeys.Split(';');
+        if (storedKeys.Equals(""))
+        {
+            string[] EmptyStringArray = {};
+            return EmptyStringArray;
+        }
+        else
+        {
+            return storedKeys.Split(';');
+        }
     }
 
     public static void DeleteAllForPlayer()
     {
-        string[] keys = getKeys();
+        string[] keys = GetKeys();
         foreach (string key in keys)
         {
             DeleteKey(key);
         }
         storedKeys = "";
-        SetString("All_Stored_Keys_For_This_Name", storedKeys);
+        PlayerPrefs.SetString(name + "_All_Stored_Keys_For_This_Name", storedKeys);
     }
     #endregion
 
@@ -122,6 +137,7 @@ public class PersistentData : PlayerPrefs
     {
         StoreKey(key);
         PlayerPrefs.SetInt(name + "_" + key, value);
+        Debug.Log(storedKeys);
     }
 
     /// <summary>
@@ -201,7 +217,7 @@ public class PersistentData : PlayerPrefs
         PlayerPrefs.DeleteKey(name + "_" + key);
 
         //If the key was storing a value for a player then this will find the index of where it was stored
-        string[] keys = getKeys();
+        string[] keys = GetKeys();
         int indexToRemove = -1;
         for (int i = 0; i < keys.Length; i++)
         {
@@ -226,7 +242,7 @@ public class PersistentData : PlayerPrefs
                 }
             }
             storedKeys = newStoredKeys;
-            PersistentData.SetString("All_Stored_Keys_For_This_Name", storedKeys);
+            PlayerPrefs.SetString(name + "_All_Stored_Keys_For_This_Name", storedKeys);
         }
     }
     #endregion

--- a/Assets/Scripts/PersistentData.cs
+++ b/Assets/Scripts/PersistentData.cs
@@ -1,0 +1,236 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+///   <para>`PersistentData` is a class that extends the functionality of PlayerPrefs and stores Player preferences between game sessions. It can store string, float and integer values into the user’s platform registry. These values are stored dependant on what the player's name is set to.</para>
+/// </summary>
+public class PersistentData : PlayerPrefs
+{
+
+    #region name
+    private static string name = PlayerPrefs.GetString("name", "none");
+    private static string storedKeys = PersistentData.GetString("All_Stored_Keys_For_This_Name");
+
+    /// <summary>
+    ///   <para>Sets the name of the Player name to uniquely generate and retrive keys for each player name.</para>
+    /// </summary>
+    /// <param name="newName"></param>
+    public static void SetPlayerName(string newName)
+    {
+        PlayerPrefs.SetString("name", newName);
+        name = newName;
+        storedKeys = PlayerPrefs.GetString(name + "_All_Stored_Preferences_For_This_Name");
+    }
+
+
+    /// <summary>
+	///   <para>Returns the Player name that is being used to uniquely generate and retrive keys.</para>
+	/// </summary>
+    public static string GetPlayerName()
+    {
+        return name;
+    }
+    #endregion
+
+
+
+    #region Store Keys
+    private static void StoreKey(string key)
+    {
+        if (!HasKey(key))
+        {
+            storedKeys += ";" + key;
+            SetString("All_Stored_Keys_For_This_Name", storedKeys);
+        }
+    }
+
+    public static string[] getKeys()
+    {
+        return storedKeys.Split(';');
+    }
+
+    public static void DeleteAllForPlayer()
+    {
+        string[] keys = getKeys();
+        foreach (string key in keys)
+        {
+            DeleteKey(key);
+        }
+        storedKeys = "";
+        SetString("All_Stored_Keys_For_This_Name", storedKeys);
+    }
+    #endregion
+
+
+
+    #region String Functions
+    /// <summary>
+    ///   <para>Sets a single string value for the preference identified by the given key. You can use PersistentData.GetString to retrieve this value.</para>
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    new public static void SetString(string key, string value)
+    {
+        if (key.Equals("name"))
+        {
+            SetPlayerName(value);
+        }
+        else
+        {
+            StoreKey(key);
+            PlayerPrefs.SetString(name + "_" + key, value);
+        }
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static string GetString(string key)
+    {
+        if (key.Equals("name"))
+            return name;
+        else
+            return PlayerPrefs.GetString(name + "_" + key);
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static string GetString(string key, string defaultValue)
+    {
+        if (key.Equals("name"))
+            return name;
+        else
+            return PlayerPrefs.GetString(name + "_" + key, defaultValue);
+    }
+    #endregion
+
+
+
+    #region Int Functions
+    /// <summary>
+    ///   <para>Sets a single integer value for the preference identified by the given key. You can use PersistentData.GetInt to retrieve this value.</para>
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    new public static void SetInt(string key, int value)
+    {
+        StoreKey(key);
+        PlayerPrefs.SetInt(name + "_" + key, value);
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static int GetInt(string key)
+    {
+        return PlayerPrefs.GetInt(name + "_" + key);
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static int GetInt(string key, int defaultValue)
+    {
+        return PlayerPrefs.GetInt(name + "_" + key, defaultValue);
+    }
+    #endregion
+
+
+
+    #region Float Functions
+    /// <summary>
+    ///   <para>Sets the float value of the preference identified by the given key. You can use PersistentData.GetFloat to retrieve this value.</para>
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    new public static void SetFloat(string key, float value)
+    {
+        StoreKey(key);
+        PlayerPrefs.SetFloat(name + "_" + key, value);
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static float GetFloat(string key)
+    {
+        return PlayerPrefs.GetFloat(name + "_" + key);
+    }
+
+    /// <summary>
+	///   <para>Returns the value corresponding to key in the preference file if it exists.</para>
+	/// </summary>
+	/// <param name="key"></param>
+	/// <param name="defaultValue"></param>
+    new public static float GetFloat(string key, float defaultValue)
+    {
+        return PlayerPrefs.GetFloat(name + "_" + key, defaultValue);
+    }
+    #endregion
+
+
+
+    #region Other Function Overrides
+    /// <summary>
+    ///   <para>Returns true if the given key exists in PersistentData, otherwise returns false.</para>
+    /// </summary>
+    /// <param name="key"></param>
+    new public static bool HasKey(string key)
+    {
+        return PlayerPrefs.HasKey(name + "_" + key);
+    }
+
+    /// <summary>
+    ///   <para>Removes the given key from the PersistentData. If the key does not exist, DeleteKey has no impact.</para>
+    /// </summary>
+    /// <param name="key"></param>
+    new public static void DeleteKey(string key)
+    {
+        PlayerPrefs.DeleteKey(name + "_" + key);
+
+        //If the key was storing a value for a player then this will find the index of where it was stored
+        string[] keys = getKeys();
+        int indexToRemove = -1;
+        for (int i = 0; i < keys.Length; i++)
+        {
+            if (keys[i].Equals(key))
+            {
+                indexToRemove = i;
+                break;
+            }
+        }
+
+        //True if the key was previously used
+        if (indexToRemove != -1)
+        {
+            string newStoredKeys = "";
+            for (int i = 0; i < keys.Length; i++)
+            {
+                if (i != indexToRemove)
+                {
+                    newStoredKeys += keys[i];
+                    if (i != keys.Length - 1)
+                        newStoredKeys += ";";
+                }
+            }
+            storedKeys = newStoredKeys;
+            PersistentData.SetString("All_Stored_Keys_For_This_Name", storedKeys);
+        }
+    }
+    #endregion
+
+
+
+}

--- a/Assets/Scripts/PersistentData.cs.meta
+++ b/Assets/Scripts/PersistentData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d25fa8a7523e242c2a518283b3cd6d3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerName.cs
+++ b/Assets/Scripts/PlayerName.cs
@@ -2,12 +2,13 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
 
 
 public class PlayerName : MonoBehaviour
 {
-    [SerializeField] public static string nameOfPlayer;
-    [SerializeField] public string saveName;
+    //[SerializeField] public static string nameOfPlayer;
+    //[SerializeField] public string saveName;
 
     public Text inputText;
     public Text loadedName;
@@ -17,21 +18,48 @@ public class PlayerName : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        string nameOfPlayer = PersistentData.GetPlayerName();
+        if (nameOfPlayer.Equals(""))
+        {
+            loadedName.gameObject.SetActive(false);
+        }
+        else
+        {
+            loadedName.text = "Hello, " + nameOfPlayer + "!";
+        }
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-        nameOfPlayer = PlayerPrefs.GetString("name", "none");
-        loadedName.text = "Hello, " + nameOfPlayer + "!";
-    }
 
+    /// <summary>
+    /// This function is being called by the save button in the PlayerName scene.
+    /// If the player has inputted a valid name then all attributes pertaining to that name are updated.
+    /// </summary>
     public void SetName()
     {
-        PlayerPrefs.DeleteAll();
-        saveName = inputText.text;
-        PlayerPrefs.SetString("name", saveName);
-        GetPlayerName.playerName = nameOfPlayer;
+        string newNameOfPlayer = inputText.text;
+        if (!newNameOfPlayer.Equals(""))
+        {
+            PersistentData.SetPlayerName(newNameOfPlayer);
+            loadedName.gameObject.SetActive(true);
+            loadedName.text = "Hello, " + newNameOfPlayer + "!";
+
+            //The following line is old code. Player name should be retreaved by other game components using PersistentData.GetPlayerName().
+            //While this should be redundant I am keeping it for the time being since I am unsure of all of the gameObjects that use it.
+            //TODO : Remove all refrences to the GetPlayerName C# script and remove this line.
+            GetPlayerName.playerName = newNameOfPlayer;
+        }
+    }
+
+
+    /// <summary>
+    /// This function is being called by the confirm button in the PlayerName scene.
+    /// If the player has inputted a valid name then they are taken to the main screen.
+    /// </summary>
+    public void ConfirmName()
+    {
+        if (!PersistentData.GetPlayerName().Equals(""))
+        {
+            SceneManager.LoadScene("StartScreen");
+        }
     }
 }

--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Scripts",
+    "rootNamespace": "",
+    "references": [
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Scripts.asmdef.meta
+++ b/Assets/Scripts/Scripts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d077eb0bf530747aabe50b0af908a449
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests.meta
+++ b/Assets/Scripts/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6067f3f99e23435987d2b19931843bb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/TestPersistentData.cs
+++ b/Assets/Scripts/Tests/TestPersistentData.cs
@@ -1,0 +1,201 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+
+
+    public class TestPersistentData
+    {
+        
+        [Test]
+        public void PersistentData_removes_keys_after_call_to_DeleteAllForPlayer()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.SetInt("UnitTestInt2", 2);
+            
+            PersistentData.DeleteAllForPlayer();
+            
+            int numberOfKeys = PersistentData.GetKeys().Length;
+            Assert.AreEqual(0, numberOfKeys);
+        }
+
+        [Test]
+        public void PersistentData_does_not_remove_other_players_removes_keys_after_call_to_DeleteAllForPlayer()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.SetInt("UnitTestInt2", 2);
+
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            int numberOfKeys = PersistentData.GetKeys().Length;
+            
+            Assert.AreEqual(2, numberOfKeys);
+        }
+
+
+        [Test]
+        public void PersistentData_stores_the_players_keys_correctly_1_key()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+
+            Assert.IsTrue(PersistentData.GetKeys().Length == 1 &&
+                PersistentData.GetKeys()[0].Equals("UnitTestInt1"));
+        }
+
+
+        [Test]
+        public void PersistentData_stores_the_players_keys_correctly_2_keys()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.SetInt("UnitTestInt2", 2);
+
+            Assert.IsTrue(PersistentData.GetKeys().Length == 2 &&
+                PersistentData.GetKeys()[0].Equals("UnitTestInt1") &&
+                PersistentData.GetKeys()[1].Equals("UnitTestInt2"));
+        }
+
+        [Test]
+        public void PersistentData_stores_the_players_keys_correctly_with_multiple_players()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.SetInt("UnitTestInt2", 2);
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt3", 3);
+
+            PersistentData.SetPlayerName("UnitTestName1");
+            Assert.IsTrue(PersistentData.GetKeys().Length == 2 &&
+                PersistentData.GetKeys()[0].Equals("UnitTestInt1") &&
+                PersistentData.GetKeys()[1].Equals("UnitTestInt2"));
+        }
+
+        [Test]
+        public void PersistentData_stores_string_values_correctly()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetString("UnitTestString1", "String 1");
+            PersistentData.SetString("UnitTestString2", "String 2");
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetString("UnitTestString1", "String 3");
+            PersistentData.SetString("UnitTestString2", "String 4");
+
+            PersistentData.SetPlayerName("UnitTestName1");
+            Assert.AreEqual("String 1", PersistentData.GetString("UnitTestString1"));
+        }
+
+        [Test]
+        public void PersistentData_stores_float_values_correctly()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetFloat("UnitTestFloat1", 0.1f);
+            PersistentData.SetFloat("UnitTestFloat2", 0.2f);
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetFloat("UnitTestFloat1", 0.3f);
+            PersistentData.SetFloat("UnitTestFloat2", 0.4f);
+
+            PersistentData.SetPlayerName("UnitTestName1");
+            Assert.AreEqual(0.1f, PersistentData.GetFloat("UnitTestFloat1"), 0.0000001f);
+        }
+
+        [Test]
+        public void PersistentData_stores_int_values_correctly()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.SetInt("UnitTestInt2", 2);
+
+            PersistentData.SetPlayerName("UnitTestName2");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 3);
+            PersistentData.SetInt("UnitTestInt2", 4);
+
+            PersistentData.SetPlayerName("UnitTestName1");
+            Assert.AreEqual(1, PersistentData.GetInt("UnitTestInt1"));
+        }
+
+        [Test]
+        public void PersistentData_HasKey()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+
+            Assert.IsTrue(PersistentData.HasKey("UnitTestInt1"));
+        }
+
+        [Test]
+        public void PersistentData_HasKey_key_not_yet_used()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+
+            Assert.IsFalse(PersistentData.HasKey("UnitTestInt7"));
+        }
+
+
+        /// <summary>
+        /// Confirms that the key is deleted after a call to the DeleteKey function
+        /// </summary>
+        [Test]
+        public void PersistentData_HasKey_after_DeleteKey()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+            PersistentData.DeleteAllForPlayer();
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.DeleteKey("UnitTestInt1");
+
+
+            Assert.IsFalse(PersistentData.HasKey("UnitTestInt1"));
+        }
+
+        [Test]
+        public void PersistentData_HasKey_after_DeleteAllForPlayer()
+        {
+            PersistentData.SetPlayerName("UnitTestName1");
+
+            PersistentData.SetInt("UnitTestInt1", 1);
+            PersistentData.DeleteAllForPlayer();
+
+            Assert.IsFalse(PersistentData.HasKey("UnitTestInt1"));
+        }
+
+
+        //// A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
+        //// `yield return null;` to skip a frame.
+        //[UnityTest]
+        //public IEnumerator TestPersistentDataWithEnumeratorPasses()
+        //{
+        //    // Use the Assert class to test conditions.
+        //    // Use yield to skip a frame.
+        //    yield return null;
+        //}
+    }
+}

--- a/Assets/Scripts/Tests/TestPersistentData.cs.meta
+++ b/Assets/Scripts/Tests/TestPersistentData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 965e951b439ae4fce95db049918164bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/Tests.asmdef
+++ b/Assets/Scripts/Tests/Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Scripts"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Tests/Tests.asmdef.meta
+++ b/Assets/Scripts/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9d0fd3c36cf304ca499ed8408b08325c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/SliderX.cs
+++ b/Assets/Scripts/UI/SliderX.cs
@@ -44,6 +44,7 @@ public class SliderX : MonoBehaviour
         if (Settings.profile)
         {
             Settings.profile.SetAudioLevels(volumeName, value);
+            Settings.profile.SaveAudioLevels();
         }
     }
 


### PR DESCRIPTION
Added in the ability for the player to change their name from the settings menu.
The three volume sliders have been joined together in the settings menu.

PlayerPrefs has been replaced by PersistentData. PersistentData is a subclass of PlayerPrefs. It differentiates itself by storing the data based on the Player's name. If the player changes their name then all level progress, achievements, etc will be reset. If the user then inputs in a previous name they will regain that progress, achievements, etc. 

Unit tests were created to check the functionality of PersistentData.

The only attribute not stored with the PersistentData class is the game volume as changing the Player name and having the volume increase would not be expected or desired functionality.